### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,7 +1112,7 @@ If you want to use more LNS-worker, you can specify
 the different cores should be used by configuring/reordering.
 
 ```
-solver.parameters.subsolvers = ["default_lp", "fixed", "less_encoding", "no_lp", "max_lp", "pseudo_costs", "reduced_costs", "quick_restart", "quick_restart_no_lp", "lb_tree_search", "probing"]
+solver.parameters.subsolvers.extend(["default_lp", "fixed", "less_encoding", "no_lp", "max_lp", "pseudo_costs", "reduced_costs", "quick_restart", "quick_restart_no_lp", "lb_tree_search", "probing"])
 ```
 
 This can be interesting, e.g., if you are using CP-SAT especially because the

--- a/README.md
+++ b/README.md
@@ -1112,6 +1112,10 @@ If you want to use more LNS-worker, you can specify
 the different cores should be used by configuring/reordering.
 
 ```
+# make sure list is empty
+while solver.paramters.subsolvers:
+   solver.parameters.subsolvers.pop()
+# set new list
 solver.parameters.subsolvers.extend(["default_lp", "fixed", "less_encoding", "no_lp", "max_lp", "pseudo_costs", "reduced_costs", "quick_restart", "quick_restart_no_lp", "lb_tree_search", "probing"])
 ```
 


### PR DESCRIPTION
Setting subsolvers got the following error message:
```
Traceback (most recent call last):
  File "/Users/chek-manh/Documents/code/python/cp_sat.py", line 44, in <module>
    SimpleSatProgram()
  File "/Users/chek-manh/Documents/code/python/cp_sat.py", line 34, in SimpleSatProgram
    solver.parameters.subsolvers = ["default_lp", "fixed", "less_encoding", "no_lp", "max_lp", "pseudo_costs", "reduced_cos
ts", "quick_restart", "quick_restart_no_lp", "lb_tree_search", "probing"]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: Assignment not allowed to message, map, or repeated field "subsolvers" in protocol message object.
```

This can be avoided by using the extend function.

