### PR TITLE
Add log_search_progress to Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3682,6 +3682,7 @@ class KnapsackInstance(BaseModel):
 class KnapsackSolverConfig(BaseModel):
     time_limit: PositiveInt = 900  # Solver time limit in seconds
     opt_tol: NonNegativeFloat = 0.01  # Optimality tolerance (1% gap allowed)
+    log_search_progress: bool = False
 
 
 class KnapsackSolution(BaseModel):
@@ -3701,6 +3702,7 @@ def solve_knapsack(
     solver = cp_model.CpSolver()
     solver.parameters.max_time_in_seconds = config.time_limit
     solver.parameters.relative_gap_limit = config.opt_tol
+    solver.parameters.log_search_progress = config.log_search_progress
     status = solver.Solve(model)
     if status in [cp_model.OPTIMAL, cp_model.FEASIBLE]:
         return KnapsackSolution(


### PR DESCRIPTION
Been loving this resource, super helpful!

Very small change, the `log_search_progress` config variable is used in the next section (https://github.com/d-krupke/cpsat-primer#solver-class), and if we run that, it causes a crash since the config variable is not included in the previous section (this one).

Not sure if it was intentional to keep the readers on their toes but figured I'd include it anyway :) 