### PR TITLE
Example chapter: Improve status code display and table entry

### DIFF
--- a/02_example.md
+++ b/02_example.md
@@ -63,15 +63,15 @@ model.maximize(30 * x + 50 * y)
 
 # Solve
 solver = cp_model.CpSolver()
-status = solver.solve(model)
+status_code = solver.solve(model)
+status_name = solver.status_name()
 
-# The status tells us if we were able to compute an optimal solution.
-assert status == cp_model.OPTIMAL, "Could not find optimal solution."
-
-# Print the optimal solution.
+# Print the solver status and the optimal solution.
+print(f"{status_name} ({status_code})")
 print(f"x={solver.value(x)},  y={solver.value(y)}")
 ```
 
+    OPTIMAL (4)
     x=0,  y=30
 
 Pretty easy, right? For solving a generic problem, not just one specific
@@ -91,8 +91,7 @@ model by hand for larger instances.
 > | `INFEASIBLE`    | 3    | The model has no feasible solution. This means that your constraints are too restrictive.                                                                                             |
 > | `OPTIMAL`       | 4    | The model has an optimal solution. If your model does not have an objective, `OPTIMAL` is returned instead of `FEASIBLE`.                                                             |
 >
-> The status `UNBOUNDED` does _not_ exist, as CP-SAT does not have unbounded
-> variables.
+> The status `UNBOUNDED` does _not_ exist, as CP-SAT does not have unbounded variables.
 
 For larger models, CP-SAT will unfortunately not always able to compute an
 optimal solution. However, the good news is that the solver will likely still

--- a/README.md
+++ b/README.md
@@ -306,15 +306,15 @@ model.maximize(30 * x + 50 * y)
 
 # Solve
 solver = cp_model.CpSolver()
-status = solver.solve(model)
+status_code = solver.solve(model)
+status_name = solver.status_name()
 
-# The status tells us if we were able to compute an optimal solution.
-assert status == cp_model.OPTIMAL, "Could not find optimal solution."
-
-# Print the optimal solution.
+# Print the solver status and the optimal solution.
+print(f"{status_name} ({status_code})")
 print(f"x={solver.value(x)},  y={solver.value(y)}")
 ```
 
+    OPTIMAL (4)
     x=0,  y=30
 
 Pretty easy, right? For solving a generic problem, not just one specific
@@ -334,8 +334,7 @@ model by hand for larger instances.
 > | `INFEASIBLE`    | 3    | The model has no feasible solution. This means that your constraints are too restrictive.                                                                                             |
 > | `OPTIMAL`       | 4    | The model has an optimal solution. If your model does not have an objective, `OPTIMAL` is returned instead of `FEASIBLE`.                                                             |
 >
-> The status `UNBOUNDED` does _not_ exist, as CP-SAT does not have unbounded
-> variables.
+> The status `UNBOUNDED` does _not_ exist, as CP-SAT does not have unbounded variables.
 
 For larger models, CP-SAT will unfortunately not always able to compute an
 optimal solution. However, the good news is that the solver will likely still


### PR DESCRIPTION
- Small improvement to example chapter by displaying the status name and code instead of only asserting the status code. Displaying the solver status more explicitly gives the reader a better idea of what this is before seeing the table of status codes right after. 
- Also, a small fix to last row in the table.